### PR TITLE
Logout from multiple clients

### DIFF
--- a/selenium/tests/logout.test.js
+++ b/selenium/tests/logout.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable */
+/**
+ * @file
+ * Mainly testing the consent page. When the flow is finished a consent will be stored in memory on the testuser
+ * (5555666677).
+ * Therefore from this testsuite and onwards the give-/reject-consent page will be skipped.
+ */
+import {assert} from 'chai';
+
+import LoginPage from '../pageObjects/loginPage';
+
+describe('Test Consent part of authetication flow', () => {
+  let loginPage = null;
+  let serviceClient = null;
+
+  beforeEach(() => {
+    loginPage = new LoginPage();
+    loginPage.login('unilogin');
+  });
+
+  afterEach(() => {
+   browser.deleteCookie();
+   browser.wipeStores();
+  });
+
+  it('should send user to generic logout screen', () => {
+    browser.url('/logout');
+
+    const content = browser.getText('.h3');
+    const expected = "Du er logget ud";
+    assert.equal(content, expected);
+  });
+
+  it('should send user to serviceclient specific logout screen', () => {
+    browser.url(`/logout/?token=${loginPage.validToken}`);
+    
+    // Test returnlink.
+    const returnLink = browser.element('#returnUrl');
+    assert.equal(returnLink.getText(), 'Tilbage til Test Service');
+    assert.equal(returnLink.getAttribute('href'), 'http://localhost:3011/example/');
+
+    // Test ipd info is present.
+    assert.equal(browser.getText('.ipdinfo'), 'Du kan stadig være logget ind på de sider, hvor du har benyttet Bibliotekslogin.');
+
+
+  });
+
+  it('should clear session after logout', () => {
+    // Check if session is set.
+    let session = browser.getSession();
+    assert.isTrue(session.user.identityProviders.includes('unilogin'));
+    
+    // Test if session is cleared after logout.
+    browser.url(`/logout/?token=${loginPage.validToken}`);
+    session = browser.getSession();
+    assert.isNull(session);
+  });
+});

--- a/src/Templates/Logout.pug
+++ b/src/Templates/Logout.pug
@@ -9,14 +9,14 @@ block append content
       div.buffer-1-1
         strong Du er logget ud af Bibliotekslogin.
       if idpLogoutInfo
-        div.buffer-1-1
+        div.buffer-1-1.ipdinfo
           strong Du kan stadig være logget ind på de sider, hvor du har benyttet Bibliotekslogin.
         div.buffer-1-1
           strong Hvis du vil logge ud af alle sider, skal du derfor lukke alle vinduer og faner i din browser
     div &nbsp;
     div.buffer-vertical-5
     if returnurl
-      a(class="link-style" href=returnurl) Tilbage til #{serviceName}
+      a(id="returnUrl" class="link-style" href=returnurl) Tilbage til #{serviceName}
     else
-      a(class="link-style" onClick='window.history.back(); return false;') Tilbage
+      a(id="returnUrl" class="link-style" onClick='window.history.back(); return false;') Tilbage
   div &nbsp;

--- a/src/Templates/Logout.pug
+++ b/src/Templates/Logout.pug
@@ -3,7 +3,6 @@ extends Main
 block append content
   div
     span.logout-img
-  if loginFound
     div
       div.h3
         strong Du er logget ud
@@ -20,15 +19,4 @@ block append content
       a(class="link-style" href=returnurl) Tilbage til #{serviceName}
     else
       a(class="link-style" onClick='window.history.back(); return false;') Tilbage
-  else
-    div
-      div.h3
-        strong Fejl
-      div.buffer-1-1
-        strong Du var ikke logget ind med Bibliotekslogin
-      div &nbsp;
-      div.buffer-vertical-5
-        a(class="link-style" onClick='window.history.back(); return false;') Tilbage
-    div &nbsp;
-
   div &nbsp;

--- a/src/components/Logout/__tests__/logout.test.js
+++ b/src/components/Logout/__tests__/logout.test.js
@@ -1,0 +1,74 @@
+import {assert} from 'chai';
+import {CONFIG} from '../../../utils/config.util';
+import {logout} from '../logout.component';
+import {mockContext} from '../../../utils/test.util';
+import sinon from 'sinon';
+import {mockData} from '../../Smaug/mock/smaug.client.mock';
+
+describe('Test Logout component', () => {
+
+  // Contains the context object
+  let ctx;
+
+  beforeEach(() => {
+    CONFIG.mock_externals.smaug = true;
+    ctx = mockContext(CONFIG.test.token);
+  });
+
+  afterEach(() => {
+    mockData.logoutScreen = 'include';
+  });
+
+
+  it('should export functions', () => {
+    assert.isFunction(logout);
+  });
+
+  it('should render generic logout screen', async () => {
+    ctx = mockContext();
+    ctx.render = sinon.spy();
+    await logout(ctx, () => {});
+    assert.deepEqual(ctx.render.args[0][1], {
+      idpLogoutInfo: false,
+      returnurl: '',
+      serviceName: null
+    });
+  });
+
+  it('should render returnurl and name for serviceclient', async () => {
+    ctx.render = sinon.spy();
+    await logout(ctx, () => {});
+    assert.deepEqual(ctx.render.args[0][1], {
+      idpLogoutInfo: null,
+      returnurl: 'http://localhost:3011/some_url',
+      serviceName: 'Test Service'
+    });
+  });
+
+  it('should render idp message', async () => {
+    ctx.session.user.identityProviders = ['unilogin'];
+    ctx.render = sinon.spy();
+    await logout(ctx, () => {});
+    assert.deepEqual(ctx.render.args[0][1], {
+      idpLogoutInfo: true,
+      returnurl: 'http://localhost:3011/some_url',
+      serviceName: 'Test Service'
+    });
+  });
+
+  it('should redirect to returnurl', async () => {
+    mockData.logoutScreen = 'skip';
+    ctx.render = sinon.spy();
+    ctx.redirect = sinon.spy();
+    await logout(ctx, () => {});
+    assert.deepEqual(ctx.redirect.args[0][0], 'http://localhost:3011/some_url?message=logout');
+  });
+  it('should redirect to returnurl with close browser message', async () => {
+    ctx.session.user.identityProviders = ['unilogin'];
+    mockData.logoutScreen = 'skip';
+    ctx.render = sinon.spy();
+    ctx.redirect = sinon.spy();
+    await logout(ctx, () => {});
+    assert.deepEqual(ctx.redirect.args[0][0], 'http://localhost:3011/some_url?message=logout_close_browser');
+  });
+});

--- a/src/components/Logout/logout.component.js
+++ b/src/components/Logout/logout.component.js
@@ -17,7 +17,6 @@ import {getClientInfo} from '../Smaug/smaug.component';
  */
 export async function logout(ctx, next) {
   let returnUrl = '';
-  let loginFound = false;
   let idpLogoutInfo = false;
   let idpLogoutUrl = '';
   let logoutInfoCode = '';
@@ -27,14 +26,13 @@ export async function logout(ctx, next) {
   const user = ctx.getUser();
   const state = ctx.getState();
   if (serviceClient && state) {
-    loginFound = true;
     if (user.identityProviders && !ctx.getState().logoutGatewayf && (user.identityProviders.includes('nemlogin') || user.identityProviders.includes('wayf'))) {
       ctx.setState({logoutGatewayf: true, returnUrl: ctx.query.returnurl || ctx.getState().returnUrl});
       idpLogoutUrl = getGateWayfLogoutUrl();
     }
     else {
       returnUrl = buildReturnUrl(ctx.getState());
-      idpLogoutInfo = user.identityProviders && (user.identityProviders.includes('unilogin') || user.identityProviders.includes('wayf'));
+      idpLogoutInfo = user.identityProviders && (user.identityProviders.includes('unilogin') || user.identityProviders.includes('wayf')) || null;
       if (serviceClient.logoutScreen === 'skip') {
         logoutInfoCode = 'logout';
         if (idpLogoutInfo) {
@@ -56,7 +54,6 @@ export async function logout(ctx, next) {
     else {
       ctx.render('Logout', {
         idpLogoutInfo: idpLogoutInfo,
-        loginFound: loginFound,
         returnurl: returnUrl,
         serviceName: serviceClient && serviceClient.name
       });

--- a/src/components/Logout/logout.component.js
+++ b/src/components/Logout/logout.component.js
@@ -4,6 +4,7 @@
 
 import buildReturnUrl from '../../utils/buildReturnUrl.util';
 import {getGateWayfLogoutUrl} from '../GateWayf/gatewayf.component';
+import {getClientInfo} from '../Smaug/smaug.component';
 
 /**
  *
@@ -16,27 +17,25 @@ import {getGateWayfLogoutUrl} from '../GateWayf/gatewayf.component';
  */
 export async function logout(ctx, next) {
   let returnUrl = '';
-  let serviceName;
   let loginFound = false;
   let idpLogoutInfo = false;
   let idpLogoutUrl = '';
   let logoutInfoCode = '';
-
+  const token = ctx.query.token;
+  const serviceClient = await getClientInfo(token);
+  ctx.setState({serviceClient});
   const user = ctx.getUser();
-  if (ctx.session.state && user) {
+  const state = ctx.getState();
+  if (serviceClient && state) {
     loginFound = true;
-    if (!ctx.getState().logoutGatewayf && (user.identityProviders.includes('nemlogin') || user.identityProviders.includes('wayf'))) {
+    if (user.identityProviders && !ctx.getState().logoutGatewayf && (user.identityProviders.includes('nemlogin') || user.identityProviders.includes('wayf'))) {
       ctx.setState({logoutGatewayf: true, returnUrl: ctx.query.returnurl || ctx.getState().returnUrl});
       idpLogoutUrl = getGateWayfLogoutUrl();
     }
     else {
-      if (ctx.query.returnurl) {
-        ctx.setState({returnUrl: ctx.query.returnurl});
-      }
       returnUrl = buildReturnUrl(ctx.getState());
-      idpLogoutInfo = (user.identityProviders.includes('unilogin') || user.identityProviders.includes('wayf'));
-      serviceName = ctx.getState().serviceClient.name;
-      if (ctx.getState().serviceClient.logoutScreen === 'skip') {
+      idpLogoutInfo = user.identityProviders && (user.identityProviders.includes('unilogin') || user.identityProviders.includes('wayf'));
+      if (serviceClient.logoutScreen === 'skip') {
         logoutInfoCode = 'logout';
         if (idpLogoutInfo) {
           logoutInfoCode = 'logout_close_browser';
@@ -59,9 +58,10 @@ export async function logout(ctx, next) {
         idpLogoutInfo: idpLogoutInfo,
         loginFound: loginFound,
         returnurl: returnUrl,
-        serviceName: serviceName
+        serviceName: serviceClient && serviceClient.name
       });
     }
+
   }
 
   await next();

--- a/src/components/Smaug/smaug.component.js
+++ b/src/components/Smaug/smaug.component.js
@@ -11,13 +11,13 @@ import {CONFIG} from '../../utils/config.util';
  * @param next
  */
 export async function getAttributes(ctx, next) {
-  try {
-    const serviceClient = await getClientInfo(ctx.getState().smaugToken);
+  const serviceClient = await getClientInfo(ctx.getState().smaugToken);
+  if (!serviceClient) {
+    ctx.status = 403;
+  }
+  else {
     ctx.setState({serviceClient});
     await next();
-  }
-  catch (err) {
-    ctx.status = 403;
   }
 }
 

--- a/src/components/Smaug/smaug.component.js
+++ b/src/components/Smaug/smaug.component.js
@@ -12,13 +12,23 @@ import {CONFIG} from '../../utils/config.util';
  */
 export async function getAttributes(ctx, next) {
   try {
-    const client = await getClientFromSmaug(ctx.getState().smaugToken);
-    ctx.setState({serviceClient: extractClientInfo(client)});
+    const serviceClient = await getClientInfo(ctx.getState().smaugToken);
+    ctx.setState({serviceClient});
     await next();
   }
   catch (err) {
-    log.error('Invalid Token', {error: err.message, stack: err.stack});
     ctx.status = 403;
+  }
+}
+
+export async function getClientInfo(smaugToken) {
+  try {
+    const smaugClient = await getClientFromSmaug(smaugToken);
+    return await extractClientInfo(smaugClient);
+  }
+  catch (error) {
+    log.info('Invalid Token', {error: error.message, stack: error.stack});
+    return null;
   }
 }
 
@@ -43,7 +53,7 @@ export async function getAuthenticatedToken(ctx, next) {
  * @param client
  * @returns {{id: String, identityProviders: Array, attributes: Array}}
  */
-function extractClientInfo(client) {
+export function extractClientInfo(client) {
   if (!client.app.clientId) {
     throw new Error('Invalid Client', client);
   }

--- a/src/middlewares/state.middleware.js
+++ b/src/middlewares/state.middleware.js
@@ -62,7 +62,7 @@ function setState(newValues) {
  * @returns {Object}
  */
 function getState() {
-  return this.session.state;
+  return this.session && this.session.state || null;
 }
 
 /**

--- a/src/routes/logout.routes.js
+++ b/src/routes/logout.routes.js
@@ -4,9 +4,10 @@
  */
 import Router from 'koa-router'; // @see https://github.com/alexmingoia/koa-router
 import {logout} from '../components/Logout/logout.component';
+import {setDefaultState} from '../middlewares/state.middleware';
 
 const router = new Router({prefix: '/logout'});
 
-router.get('/', logout);
+router.get('/', setDefaultState, logout);
 
 export default router;


### PR DESCRIPTION
Hvis en applikation medesender et token i logout url, så sendes brugeren retur til den korrekte applikation. Hvis token ikke findes eller er ugyldig, gives en generisk log ud besked. 

Brugeren bliver logget ud af adgangsplatformen i alle tilfælde