### PR TITLE
Remove help section when using locked library

### DIFF
--- a/e2e/cypress/integration/modal.js
+++ b/e2e/cypress/integration/modal.js
@@ -1,21 +1,29 @@
 context('Test modals', () => {
   const authorize =
     '/oauth/authorize?response_type=code&client_id=hejmdal&redirect_uri=http://localhost:3011/example';
-
-  beforeEach(() => {
-    cy.visit(authorize);
-  });
-
   it('test that help modal toggles', () => {
+    cy.visit(authorize);
     cy.get('[data-cy=helptext-link]').click();
     cy.get('#helpModal').should('be.visible');
+    cy.get('#helpModal h5')
+      .first()
+      .should('contain', 'Bibliotek');
+
     cy.get('#helpModal > .modal-header > button').click();
     cy.get('#helpModal').should('not.be.visible');
   });
   it('test that privacy modal toggles', () => {
+    cy.visit(authorize);
     cy.get('[data-cy=privacy-button]').click();
     cy.get('#privacyModal').should('be.visible');
     cy.get('body').type('{esc}');
     cy.get('#privacyModal').should('not.be.visible');
+  });
+  it('test that Bibliotek is removed when agency is locked', () => {
+    cy.visit(`${authorize}&agency=737000`);
+    cy.get('[data-cy=helptext-link]').click();
+    cy.get('#helpModal h5')
+      .first()
+      .should('not.contain', 'Bibliotek');
   });
 });

--- a/src/Templates/Components/modals/modal-help.pug
+++ b/src/Templates/Components/modals/modal-help.pug
@@ -4,8 +4,9 @@ div#helpModal.modal
     h4.modal-title #{help.title}
   div.modal-body
     each section in help.sections
-      div.modal-body-section
-        if(section.header)
-          h5 #{section.header}
-        each text in section.texts
-          p !{text}
+      if(!(lockedAgency && section.header == 'Bibliotek'))
+        div.modal-body-section
+          if(section.header)
+            h5 #{section.header}
+          each text in section.texts
+            p !{text}

--- a/src/utils/text.util.js
+++ b/src/utils/text.util.js
@@ -144,15 +144,15 @@ const helpTexts = {
         ]
       },
       {
-        header: 'Cpr- og lånernummer',
+        header: 'CPR- og lånernummer',
         texts: [
-          'Du skal være oprettet som bruger på biblioteket for at kunne logge ind. Du kan skrive dit cpr-nummer eller dit lånernummer i feltet. Dit lånernummer står på det lånerkort, du har fået udleveret på biblioteket, da du blev oprettet. Hvis du ikke er oprettet som låner, kan du se hvordan på bibliotekets hjemmeside eller oprette dig direkte ved at trykke på ’Opret bruger’ ved siden af log ind-knappen.'
+          'Du skal være oprettet som bruger på biblioteket for at kunne logge ind. Du kan skrive dit CPR- eller lånernummer i feltet. Dit lånernummer står på det lånerkort, du har fået udleveret på biblioteket, da du blev oprettet. Hvis du ikke er oprettet som låner, kan du se hvordan på bibliotekets hjemmeside eller oprette dig direkte ved at trykke på ’Opret bruger’ ved siden af log ind-knappen.'
         ]
       },
       {
         header: 'Pinkode',
         texts: [
-          'Pinkoden er den 4- eller 5-cifrede kode, som du bruger, når du låner på biblioteket. Hvis du ikke kan huske din kode, kan du henvende dig på det bibliotek, hvor du er oprettet som låner.'
+          'Pinkoden er den kode, som du bruger, når du låner på biblioteket. Hvis du ikke kan huske din kode, kan du henvende dig på det bibliotek, hvor du er oprettet som låner.'
         ]
       }
     ]


### PR DESCRIPTION
Part of [HEJMDAL-556]

[HEJMDAL-556]: https://dbcjira.atlassian.net/browse/HEJMDAL-556

Removes the "bibliotek" section when library is preselected, and field is not present.