### PR TITLE
Slash after /logout/ is mandatory

### DIFF
--- a/docs/single-logout.md
+++ b/docs/single-logout.md
@@ -3,9 +3,9 @@
 
 Single logout will log the user out of all applications the user has logged in to throughout a session. For this to happen, logout needs to be called with the parameter singlelogout=true, and all applications needs to have implemented a special single-logout endpoint, used by login.bib.dk to log out the user from each application. 
 
-## 1\. [login.bib.dk/logout?singlelogout=true](http://login.bib.dk/logout?singlelogout=true)
+## 1\. [login.bib.dk/logout/?singlelogout=true](http://login.bib.dk/logout?singlelogout=true)
 
-To initiate single-logout initiate a redirect to login.bib.dk/logout?singlelogout=true&access_token={ACCESS_TOKEN}&redirect_uri={REDIRECT_URI}
+To initiate single-logout initiate a redirect to login.bib.dk/logout/?singlelogout=true&access_token={ACCESS_TOKEN}&redirect_uri={REDIRECT_URI}
 
 Parameters:
 


### PR DESCRIPTION
Reference: https://github.com/ding2/ding2/blob/master/modules/ding_adgangsplatformen/ding_adgangsplatformen.module#L145

No trailing slash fails:
https://login.bib.dk/logout?singlelogout=true
Du er ved at blive logget ud af dine bibliotekstjenester
Det har ikke været muligt at logge dig ud af alle dine bibliotekstjenester. Du skal istedet lukke din browser for at logge helt ud.

With trailing slash logout is performed
https://login.bib.dk/logout/?singlelogout=true
Du er ved at blive logget ud af dine bibliotekstjenester
Du er nu blevet logget ud af bibliotekslogin