### PR TITLE
Validate return_uri against clients in session

### DIFF
--- a/e2e/cypress/integration/logout.js
+++ b/e2e/cypress/integration/logout.js
@@ -43,4 +43,12 @@ context('Logout', () => {
     cy.visit(`${authorize}`);
     cy.get('h1').should('contain', 'Log ind');
   });
+  it('should redirect to return_url without access_token, if url can be validated against client stored in session', () => {
+    cy.loginOnTestService('hejmdal-1');
+    cy.visit(`/logout?redirect_uri=${Cypress.config().baseUrl}/example`);
+    cy.location('pathname').should('eq', '/example/');
+    cy.location('search').should('contain', 'message=logout');
+    cy.visit(`${authorize}`);
+    cy.get('h1').should('contain', 'Log ind');
+  });
 });

--- a/e2e/cypress/integration/single-logout.js
+++ b/e2e/cypress/integration/single-logout.js
@@ -53,11 +53,22 @@ context('Single Logout', () => {
     cy.verifyUserOnTestService('hejmdal-5').should('equal', false);
   });
 
-  it('should redirect on succesfull logout', () => {
+  it('should redirect on succesful logout', () => {
     cy.loginOnTestService('hejmdal-1');
     cy.loginOnTestService('hejmdal-2');
     cy.visit(
       `/logout?access_token=hejmdal-1&singlelogout=true&redirect_uri=${
+        Cypress.config().baseUrl
+      }/example`
+    );
+    cy.location('pathname').should('eq', '/example/');
+  });
+
+  it('should redirect to return_url without access_token, if url can be validated against client stored in session', () => {
+    cy.loginOnTestService('hejmdal-1');
+    cy.loginOnTestService('hejmdal-2');
+    cy.visit(
+      `/logout?singlelogout=true&redirect_uri=${
         Cypress.config().baseUrl
       }/example`
     );

--- a/src/components/Logout/logout.component.js
+++ b/src/components/Logout/logout.component.js
@@ -17,8 +17,7 @@ import {log} from '../../utils/logging.util';
 
 export async function validateToken(req, res, next) {
   const {access_token, redirect_uri} = req.query;
-  const {clients = [], state = {}} = req.session;
-  console.log(clients);
+  const {clients = []} = req.session;
   let serviceClient;
   try {
     if (access_token) {

--- a/src/components/Logout/logout.component.js
+++ b/src/components/Logout/logout.component.js
@@ -17,6 +17,8 @@ import {log} from '../../utils/logging.util';
 
 export async function validateToken(req, res, next) {
   const {access_token, redirect_uri} = req.query;
+  const {clients = [], state = {}} = req.session;
+  console.log(clients);
   let serviceClient;
   try {
     if (access_token) {
@@ -25,6 +27,12 @@ export async function validateToken(req, res, next) {
       if (redirect_uri && serviceClient.redirectUris.includes(redirect_uri)) {
         req.setState({redirect_uri});
       }
+    } else if (
+      redirect_uri &&
+      clients.filter(client => client.redirectUris.includes(redirect_uri))
+        .length > 0
+    ) {
+      req.setState({redirect_uri});
     }
   } catch (e) {
     log.debug('Validate token failed', {

--- a/src/utils/oauth2.utils.js
+++ b/src/utils/oauth2.utils.js
@@ -31,7 +31,11 @@ export function addClientToListOfClients(req) {
     const singleLogoutUrl = client.singleLogoutPath
       ? `${redirectUrl.origin}${client.singleLogoutPath}`
       : null;
-    clients.push({singleLogoutUrl, clientId: client.clientId});
+    clients.push({
+      singleLogoutUrl,
+      clientId: client.clientId,
+      redirectUris: client.redirectUris
+    });
     req.session.clients = clients;
     req.session.save();
   } catch (error) {


### PR DESCRIPTION
DDB CMS is revoking token after login, and can therefore not provide a valid token on logout. Due to this we make it possible to validate return_uri against the clients in the session.

Solves [HEJMDAL-590]

[HEJMDAL-590]: https://dbcjira.atlassian.net/browse/HEJMDAL-590