### PR TITLE
Hejmdal 686

### DIFF
--- a/src/Templates/Netpunkt.pug
+++ b/src/Templates/Netpunkt.pug
@@ -37,4 +37,4 @@ block append content
                   include Components/Error
 
             div.action-container
-              button(type='submit' id='netpunkt-submit' data-cy='netpunkt-submit' tabindex='0' onmouseover=buttonColor onmouseout="this.style.backgroundColor='var(--black-lighten-1)'") Log ind
+              button(type='submit' id='netpunkt-submit' data-cy='netpunkt-submit' tabindex='0' style=btnStyle onmouseover=btnOnmouseover onmouseout=btnOnmouseout) Log ind

--- a/src/Templates/Netpunkt.pug
+++ b/src/Templates/Netpunkt.pug
@@ -6,7 +6,7 @@ block append content
       div.top
         span(id='logo')
           include ./Components/logo
-          h1 Netpunkt Login
+          h1 #{title}
 
         div#netpunkt
           form(action=idpAction autocomplete='off' method='post' id='netpunkt-login-form' onsubmit='netpunktSubmit(event)')
@@ -21,7 +21,7 @@ block append content
             div.form-group
               label(for='user-input') Bruger ID
               div.input-container
-                input(type='text' value='netpunkt' class='form-control' id='user-input' data-cy='user-input' name='userId' autocomplete='password' tabindex='0')
+                input(type='text' value=defaultUser class='form-control' id='user-input' data-cy='user-input' name='userId' autocomplete='password' tabindex='0')
               span(id='user-input-text' data-text='')
 
             div.form-group
@@ -37,4 +37,4 @@ block append content
                   include Components/Error
 
             div.action-container
-              button(type='submit' id='netpunkt-submit' data-cy='netpunkt-submit' tabindex='0') Log ind
+              button(type='submit' id='netpunkt-submit' data-cy='netpunkt-submit' tabindex='0' onmouseover=buttonColor onmouseout="this.style.backgroundColor='var(--black-lighten-1)'") Log ind

--- a/src/components/Identityprovider/identityprovider.component.js
+++ b/src/components/Identityprovider/identityprovider.component.js
@@ -115,6 +115,9 @@ export async function authenticate(req, res, next) { // eslint-disable-line comp
         serviceClient: state.serviceClient.name,
         identityProviders,
         idpAction: state.serviceClient.identityProviders.includes('netpunkt') ? identityProviders.netpunkt.action : identityProviders.dbcidp.action,
+        title: state.serviceClient.title,
+        buttonColor: "this.style.backgroundColor='" + state.serviceClient.buttonColor + "'",
+        defaultUser: state.serviceClient.identityProviders.includes('netpunkt') ? 'netpunkt' : '',
         hideFooter: true,
         loginToProfile: !!req.session.loginToProfil
       });

--- a/src/components/Identityprovider/identityprovider.component.js
+++ b/src/components/Identityprovider/identityprovider.component.js
@@ -115,9 +115,11 @@ export async function authenticate(req, res, next) { // eslint-disable-line comp
         serviceClient: state.serviceClient.name,
         identityProviders,
         idpAction: state.serviceClient.identityProviders.includes('netpunkt') ? identityProviders.netpunkt.action : identityProviders.dbcidp.action,
+        defaultUser: state.serviceClient.defaultUser,
         title: state.serviceClient.title,
-        buttonColor: "this.style.backgroundColor='" + state.serviceClient.buttonColor + "'",
-        defaultUser: state.serviceClient.identityProviders.includes('netpunkt') ? 'netpunkt' : '',
+        btnStyle: "background-color:" + state.serviceClient.buttonColor + ";color:" + state.serviceClient.buttonTxtColor,
+        btnOnmouseover: "this.style.backgroundColor='" + state.serviceClient.buttonHoverColor + "';this.style.color='" + state.serviceClient.buttonTxtHoverColor + "'",
+        btnOnmouseout: "this.style.backgroundColor='" + state.serviceClient.buttonColor + "';this.style.color='" + state.serviceClient.buttonTxtColor + "'",
         hideFooter: true,
         loginToProfile: !!req.session.loginToProfil
       });

--- a/src/components/Smaug/smaug.component.js
+++ b/src/components/Smaug/smaug.component.js
@@ -62,8 +62,12 @@ export function extractClientInfo(client) {
     clientSecret: client.app.clientSecret,
     requireConsent: !!client.requireConsent,
     logoColor: client.logoColor ? client.logoColor : '#252525',
-    title: client.layoutTitle ? client.layoutTitle : 'Netpunkt Login',
-    buttonColor: client.layoutBtnBgColor ? client.layoutBtnBgColor : '#e56312',
+    defaultUser: client.display && client.display.defaultUser !== undefined ? client.display.defaultUser : "netpunkt",
+    title: client.display && client.display.title ? client.display.title : 'Netpunkt Login',
+    buttonColor: client.display && client.display.buttonColor ? client.display.buttonColor : '#252525',
+    buttonHoverColor: client.display && client.display.buttonHoverColor ? client.display.buttonHoverColor : '#e56312',
+    buttonTxtColor: client.display && client.display.buttonTxtColor ? client.display.buttonTxtColor : '#ffffff',
+    buttonTxtHoverColor: client.display && client.display.buttonTxtHoverColor ? client.display.buttonTxtHoverColor : '#ffffff',
     singleLogoutPath: client.singleLogoutPath,
     proxy: client.proxy || false
   };

--- a/src/components/Smaug/smaug.component.js
+++ b/src/components/Smaug/smaug.component.js
@@ -62,6 +62,8 @@ export function extractClientInfo(client) {
     clientSecret: client.app.clientSecret,
     requireConsent: !!client.requireConsent,
     logoColor: client.logoColor ? client.logoColor : '#252525',
+    title: client.layoutTitle ? client.layoutTitle : 'Netpunkt Login',
+    buttonColor: client.layoutBtnBgColor ? client.layoutBtnBgColor : '#e56312',
     singleLogoutPath: client.singleLogoutPath,
     proxy: client.proxy || false
   };

--- a/src/css/netpunkt.css
+++ b/src/css/netpunkt.css
@@ -17,13 +17,4 @@
       width: 100%;
     }
   }
-
-  .action-container {
-    button {
-      &:hover,
-      &:focus {
-        background-color: var(--netpunkt);
-      }
-    }
-  }
 }


### PR DESCRIPTION
Hejmdal-686: Tilpasning af overskrift, default parametre og udseende baseret på produkt.
Tilføjet disse i clientopsætningen til at styre titel og log ind knappens farve:
"display": {
  "title": Titel på siden, defaulter til 'Netpunkt login'
  "defaultUser": Forudvalgt bruger, defaulter til 'netpunkt''
  "buttonColor": Loginknappens farve, defaulter til #252525 (næsten sort)
  "buttonTxtColor": Loginknappens tekst farve, defaulter til #ffffff (hvid)
  "buttonHoverColor": Loginknappens farve ved hover, defaulter til #e56312 (Netpunkt orange)
  "buttonTxtHoverColor": Loginknappens tekst farve ved hover, defaulter til #ffffff (hvid)
}