### PR TITLE
Add migration scripts so we can handle the changes made manually to the DB.

### DIFF
--- a/migrations/20211215101100_sessions_index.js
+++ b/migrations/20211215101100_sessions_index.js
@@ -1,0 +1,13 @@
+/**
+ * Change table sessions. Drop extra indexes in expired (May be recreated later)
+ */
+
+exports.up = function(knex) {
+  return knex.schema
+    .raw('drop index if exists sessions_expired_idx')
+    .raw('drop index if exists sessions_expired_index');
+};
+
+exports.down = function(knex) {
+    return null;
+};

--- a/migrations/20211215101200_PK_sessions_part1.js
+++ b/migrations/20211215101200_PK_sessions_part1.js
@@ -1,0 +1,16 @@
+/**
+ * Change table sessions. Drop index on sid so we can make it primary later.
+ * Also change expired and sess to not null. Add index on expired.
+ */
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('sessions', (table) => {
+      table.dropIndex('sid', 'sessions_sid_index');
+      table.dateTime('expired').notNullable().index().alter();
+      table.json('sess').notNullable().alter();
+  });
+};
+
+exports.down = function(knex) {
+    return null;
+};

--- a/migrations/20211215101200_PK_sessions_part2.js
+++ b/migrations/20211215101200_PK_sessions_part2.js
@@ -1,0 +1,35 @@
+/**
+ * Change table sessions to include a primary key on column sid.
+ */
+
+exports.up = function(knex) {
+  let alter = knex.schema.alterTable('sessions', (table) => {
+      table.primary('sid');
+  });
+
+
+  return knex.raw('SELECT a.* FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) WHERE i.indrelid = \'sessions\'::regclass AND i.indisprimary')
+  .then((resp) => {
+      if (resp.rowCount !== 0) {
+          console.error("sessions table already contains a primary key");
+          return null;
+      } else {
+          console.error("Adding Primary key to sessions table");
+          return alter;
+      }
+  },
+  () => {
+      console.error("Error when trying to query for Primary Index");
+      return null;
+  }
+  )
+  .catch(function(error) {
+    console.error("ERROR trying to alter sessions table");
+    console.error(error);
+    return null;
+  });
+};
+
+exports.down = function(knex) {
+    return null;
+};

--- a/migrations/20211215101200_PK_sessions_part3.js
+++ b/migrations/20211215101200_PK_sessions_part3.js
@@ -1,0 +1,13 @@
+/**
+ * Change table sessions drop unique index since there is already a primary index
+ */
+
+exports.up = function(knex) {
+  return knex.schema.alterTable('sessions', (table) => {
+      table.dropUnique('sid');
+  });
+};
+
+exports.down = function(knex) {
+    return null;
+};

--- a/migrations/20211215101200_PK_user.js
+++ b/migrations/20211215101200_PK_user.js
@@ -1,0 +1,37 @@
+/**
+ * Change table user to include an index on userId and make it not null.
+ */
+
+exports.up = function(knex) {
+  let alter = knex.schema.alterTable('user', (table) => {
+      table.string('userId').notNullable().index('user_userId_idx').alter();
+  });
+
+
+  return knex.raw('select t.relname as table_name, i.relname as index_name, a.attname as column_name from pg_class t, pg_class i, pg_index ix, pg_attribute a where t.oid = ix.indrelid and i.oid = ix.indexrelid and a.attrelid = t.oid and a.attnum = ANY(ix.indkey) and t.relkind = \'r\' and t.relname = \'user\' and a.attname = \'userId\'')
+  .then((resp) => {
+      if (resp.rowCount !== 0) {
+        console.error("User table already contains an index on userId ");
+        return null;
+      } else {
+        console.error("Adding index on userId to user table");
+        return knex.schema.alterTable('user', (table) => {
+                table.string('userId').notNullable().index('user_userId_idx').alter();
+                  });
+      }
+  },
+  () => {
+      console.error("Error when trying to query for index");
+      return null;
+  }
+  )
+  .catch(function(error) {
+    console.error("ERROR trying to alter user table");
+    console.error(error);
+    return null;
+  });
+};
+
+exports.down = function(knex) {
+    return null;
+};


### PR DESCRIPTION
Please verify, that the migration scripts both work on a production level database (including data) and on a blank/new database schema.