### PR TITLE
HEJMDAL-702 Remove general culr account creation

### DIFF
--- a/src/components/Culr/culr.component.js
+++ b/src/components/Culr/culr.component.js
@@ -7,7 +7,7 @@ import * as culr from './culr.client';
 import {log} from '../../utils/logging.util';
 import {validateUserInLibrary} from '../Borchk/borchk.component';
 import {CONFIG} from '../../utils/config.util';
-import {municipalityName} from '../../utils/municipality.util';
+import {populateCulr} from '../../utils/populateCulr.util';
 import {sortBy} from 'lodash';
 
 /**
@@ -250,7 +250,7 @@ async function createUser(user, agencyId) {
  * @returns
  */
 export function shouldCreateAccount(library, user, response) {
-  if (!library || !municipalityName[library]) {
+  if (!library || !populateCulr[library]) {
     return false;
   }
 

--- a/src/utils/populateCulr.util.js
+++ b/src/utils/populateCulr.util.js
@@ -1,0 +1,9 @@
+/**
+ * @file
+ *
+ * list of municipalities where users should automatically create a culr account
+ */
+
+export const populateCulr = {
+  100400: 'DBC test'
+};


### PR DESCRIPTION
Create a new list to reflect libraries where culr account should be created as part of hejmdal login, if the user is not found in culr