### PR TITLE
Ensure attribute userPrivilege is an array

### DIFF
--- a/src/utils/attribute.mapper.util.js
+++ b/src/utils/attribute.mapper.util.js
@@ -126,7 +126,7 @@ export async function mapCulrResponse(
             mapped.blocked = culr.blocked;
             break;
           case 'userPrivilege':
-            mapped.userPrivilege = culr.userPrivilege;
+            mapped.userPrivilege = [].concat(culr.userPrivilege ?? []);  // force array
             break;
           case 'municipality':
             mapped.municipality = culr.municipalityNumber || null;


### PR DESCRIPTION
If borchk returns exact one userPrivilege, it is interpreted as a string. Mapping to attributes, now enforce the parameter as an array